### PR TITLE
Adds GitHub Actions to Deploy to server

### DIFF
--- a/.github/workflows/deploy-to-server.yml
+++ b/.github/workflows/deploy-to-server.yml
@@ -1,0 +1,29 @@
+name: "Deploy to Server"
+
+on:
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@master
+      - name: "Build deployment code for standalone"
+        env:
+          remote_host: ${{ secrets.DEPLOY_HOST }}
+          remote_port: ${{ secrets.DEPLOY_PORT }}
+          remote_user: ${{ secrets.DEPLOY_USER }}
+          remote_key: ${{ secrets.DEPLOY_KEY }}
+          dev_env_file: ${{ secrets.DEV_ENV_FILE }}
+          local_dir: "build/"
+          remote_dir: "~/kmaps-apps-infrastructure/volumes/mandala-om/development/mandala-om/"
+        run: |
+          cd kmaps-app
+          npm install
+          CI=false npm run build
+          mkdir ~/.ssh
+          echo "$remote_key" > ~/.ssh/id_mandala-om
+          chmod 600 ~/.ssh/id_mandala-om
+          echo "$dev_env_file" > .env
+          chmod 600 .env
+          rsync -avzr --delete -e "ssh -p ${remote_port} -i ~/.ssh/id_mandala-om -o StrictHostKeyChecking=no" ${local_dir} ${remote_user}@${remote_host}:${remote_dir}


### PR DESCRIPTION
Adds GitHub Actions that allows the build of the React application and
then upload it via `rsync` to the Development server.

Adds validation in PlacesInfo for altitudes. The following GitHub secrets
should be added for the GH Action to work:

- DEPLOY_HOST - Server Host to deploy to
- DEPLOY_PORT - Server port to connect over SSH
- DEPLOY_USER - User to connect with
- DEPLOY_KEY   - Private Key (the public key should be added to the server's `authorized_keys`)
- DEV_ENV_FILE - The contents of the `.env` file to use on the server 
